### PR TITLE
feat: add shared memory via pgvector

### DIFF
--- a/core/agents/base.py
+++ b/core/agents/base.py
@@ -42,6 +42,7 @@ class BaseAgent:
         self.step = step
         self.data = data
         self.args = args
+        self.memory = state_manager.shared_memory
 
     @property
     def current_state(self) -> ProjectState:

--- a/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
+++ b/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
         op.execute("CREATE EXTENSION IF NOT EXISTS vector")
 
     id_col = sa.Column(
-        "id", pg.UUID(as_uuid=True) if use_pgvector else sa.String(length=36), primary_key=True
+        "id", sa.String(length=36), primary_key=True
     )
     embedding_col = sa.Column(
         "embedding",

--- a/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
+++ b/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
@@ -33,6 +33,19 @@ def upgrade() -> None:
         Vector(1536) if use_pgvector else sa.JSON(),
         nullable=False,
     )
+    op.create_table(
+        "shared_memory",
+        id_col,
+        sa.Column("agent_type", sa.String(length=50), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        embedding_col,
+    )
+    if use_pgvector:  # pragma: no branch
+        op.create_check_constraint(
+            "ck_shared_memory_embedding_dims",
+            "shared_memory",
+            "vector_dims(embedding) = 1536",
+        )
 
     op.create_table(
         "shared_memory",

--- a/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
+++ b/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
@@ -29,7 +29,9 @@ def upgrade() -> None:
         "id", pg.UUID(as_uuid=True) if use_pgvector else sa.String(length=36), primary_key=True
     )
     embedding_col = sa.Column(
-        "embedding", Vector(1536) if use_pgvector else sa.JSON(), nullable=not use_pgvector
+        "embedding",
+        Vector(1536) if use_pgvector else sa.JSON(),
+        nullable=False,
     )
 
     op.create_table(

--- a/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
+++ b/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
@@ -1,0 +1,43 @@
+"""create shared memory table"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pg
+
+try:
+    from pgvector.sqlalchemy import Vector
+except Exception:  # pragma: no cover
+    Vector = None  # type: ignore
+
+# revision identifiers, used by Alembic.
+revision: str = "8a67f9e83b3e"
+down_revision: Union[str, Sequence[str], None] = ("f708791b9270", "ff891d366761")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql" and Vector is not None:  # pragma: no branch
+        op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        op.create_table(
+            "shared_memory",
+            sa.Column("id", pg.UUID(as_uuid=True), primary_key=True),
+            sa.Column("agent_type", sa.String(length=50), nullable=False),
+            sa.Column("content", sa.Text(), nullable=False),
+            sa.Column("embedding", Vector(1536)),
+        )
+    else:
+        op.create_table(
+            "shared_memory",
+            sa.Column("id", sa.String(length=36), primary_key=True),
+            sa.Column("agent_type", sa.String(length=50), nullable=False),
+            sa.Column("content", sa.Text(), nullable=False),
+            sa.Column("embedding", sa.JSON(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("shared_memory")

--- a/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
+++ b/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
         op.execute("CREATE EXTENSION IF NOT EXISTS vector")
 
     id_col = sa.Column(
-        "id", sa.String(length=36), primary_key=True
+        "id", sa.String(length=36), primary_key=True, nullable=False
     )
     embedding_col = sa.Column(
         "embedding",

--- a/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
+++ b/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
@@ -26,7 +26,11 @@ def upgrade() -> None:
         op.execute("CREATE EXTENSION IF NOT EXISTS vector")
 
     id_col = sa.Column(
-        "id", sa.String(length=36), primary_key=True, nullable=False
+        "id",
+        sa.String(length=36),
+        primary_key=True,
+        nullable=False,
+        server_default=sa.text("gen_random_uuid()")  # requires pgcrypto; or replace with uuid_generate_v4()
     )
     embedding_col = sa.Column(
         "embedding",

--- a/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
+++ b/core/db/migrations/versions/8a67f9e83b3e_create_shared_memory_table.py
@@ -47,14 +47,6 @@ def upgrade() -> None:
             "vector_dims(embedding) = 1536",
         )
 
-    op.create_table(
-        "shared_memory",
-        id_col,
-        sa.Column("agent_type", sa.String(length=50), nullable=False),
-        sa.Column("content", sa.Text(), nullable=False),
-        embedding_col,
-    )
-
 
 def downgrade() -> None:
     bind = op.get_bind()

--- a/core/db/models/__init__.py
+++ b/core/db/models/__init__.py
@@ -13,6 +13,10 @@ from .project import Project
 from .project_state import ProjectState
 from .specification import Complexity, Specification
 from .user_input import UserInput
+try:  # pragma: no cover - optional dependency
+    from .shared_memory import SharedMemory
+except Exception:  # pragma: no cover
+    SharedMemory = None
 
 __all__ = [
     "Base",
@@ -27,3 +31,6 @@ __all__ = [
     "Specification",
     "UserInput",
 ]
+
+if SharedMemory is not None:  # pragma: no cover - optional dependency
+    __all__.append("SharedMemory")

--- a/core/db/models/shared_memory.py
+++ b/core/db/models/shared_memory.py
@@ -40,10 +40,10 @@ class SharedMemory(Base):
 
     __tablename__ = "shared_memory"
 
-    id: Mapped[Union[UUID, str]] = mapped_column(
+    id: Mapped[str] = mapped_column(
         _ID_TYPE, primary_key=True, default=_ID_DEFAULT
     )
     agent_type: Mapped[str] = mapped_column(String(50), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    embedding: Mapped[List[float]] = mapped_column(_EMBEDDING_TYPE)
+    embedding: Mapped[List[float]] = mapped_column(_EMBEDDING_TYPE, nullable=False)
 

--- a/core/db/models/shared_memory.py
+++ b/core/db/models/shared_memory.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import List
+from uuid import uuid4
+
+from sqlalchemy import String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+try:
+    from pgvector.sqlalchemy import Vector
+except Exception:  # pragma: no cover - optional dependency
+    Vector = None  # type: ignore
+
+
+class SharedMemory(Base):
+    """Shared memory record stored in PostgreSQL with pgvector support."""
+
+    __tablename__ = "shared_memory"
+
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    agent_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    if Vector is not None:  # pragma: no cover - depends on pgvector
+        embedding: Mapped[List[float]] = mapped_column(Vector(1536))  # type: ignore[arg-type]
+    else:
+        from sqlalchemy import JSON
+
+        embedding: Mapped[List[float]] = mapped_column(JSON)

--- a/core/db/models/shared_memory.py
+++ b/core/db/models/shared_memory.py
@@ -24,21 +24,15 @@ def _dialect_name() -> str:
         return ""
 
 
-_DIALECT = _dialect_name()
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
-if _DIALECT == "postgresql":  # pragma: no cover - depends on runtime engine
-    _ID_TYPE = PG_UUID(as_uuid=True)
-    _ID_DEFAULT = uuid4
-else:
-    _ID_TYPE = String(36)
-    _ID_DEFAULT = lambda: str(uuid4())
+# Always use string UUIDs at ORM level to avoid premature dialect binding issues.
+_ID_TYPE = String(36)
+_ID_DEFAULT = lambda: str(uuid4())
 
-if PGVector is not None and _DIALECT == "postgresql":  # pragma: no cover
-    Vector = PGVector  # export for callers
-    _EMBEDDING_TYPE = PGVector(1536)
-else:
-    Vector = None  # type: ignore
-    _EMBEDDING_TYPE = JSON
+# Store embeddings in JSON at ORM level; pgvector specifics handled in migrations.
+Vector = None  # type: ignore
+_EMBEDDING_TYPE = JSON
 
 
 class SharedMemory(Base):

--- a/core/db/models/shared_memory.py
+++ b/core/db/models/shared_memory.py
@@ -41,7 +41,10 @@ class SharedMemory(Base):
     __tablename__ = "shared_memory"
 
     id: Mapped[str] = mapped_column(
-        _ID_TYPE, primary_key=True, default=_ID_DEFAULT
+        _ID_TYPE,
+        primary_key=True,
+        default=_ID_DEFAULT,
+        server_default=sa.text("gen_random_uuid()")  # safe on Postgres; ignored elsewhere
     )
     agent_type: Mapped[str] = mapped_column(String(50), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)

--- a/core/memory/__init__.py
+++ b/core/memory/__init__.py
@@ -1,0 +1,3 @@
+from .shared_memory import SharedMemory
+
+__all__ = ["SharedMemory"]

--- a/core/memory/shared_memory.py
+++ b/core/memory/shared_memory.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import List
+
+from sqlalchemy import select
+
+from core.db.models.shared_memory import SharedMemory as SharedMemoryModel, Vector
+from core.db.session import SessionManager
+
+
+class SharedMemory:
+    """Vector-based shared memory accessible to all agents."""
+
+    def __init__(self, session_manager: SessionManager):
+        self.session_manager = session_manager
+
+    @property
+    def enabled(self) -> bool:
+        return Vector is not None
+
+    async def add(self, agent_type: str, content: str, embedding: List[float]):
+        if not self.enabled:
+            raise RuntimeError("pgvector is not available")
+        async with self.session_manager as session:
+            record = SharedMemoryModel(agent_type=agent_type, content=content, embedding=embedding)
+            session.add(record)
+            await session.commit()
+            return record
+
+    async def search(self, embedding: List[float], limit: int = 5) -> List[SharedMemoryModel]:
+        if not self.enabled:
+            raise RuntimeError("pgvector is not available")
+        stmt = (
+            select(SharedMemoryModel)
+            .order_by(SharedMemoryModel.embedding.cosine_distance(embedding))
+            .limit(limit)
+        )
+        async with self.session_manager as session:
+            result = await session.execute(stmt)
+            return list(result.scalars())

--- a/core/memory/shared_memory.py
+++ b/core/memory/shared_memory.py
@@ -17,15 +17,17 @@ class SharedMemory:
 
     @property
     def enabled(self) -> bool:
-        return Vector is not None
+        # Search requires pgvector; storage works with JSON fallback
+        return True
 
-    async def add(self, agent_type: str, content: str, embedding: List[float]):
-        if not self.enabled:
-            raise RuntimeError("pgvector is not available")
+    def _validate_embedding(self, embedding: List[float]):
         if len(embedding) != self.embedding_dim:
             raise ValueError(
                 f"Embedding length must be {self.embedding_dim}, got {len(embedding)}"
             )
+
+    async def add(self, agent_type: str, content: str, embedding: List[float]):
+        self._validate_embedding(embedding)
         async with self.session_manager as session:
             record = SharedMemoryModel(
                 agent_type=agent_type, content=content, embedding=embedding

--- a/core/memory/shared_memory.py
+++ b/core/memory/shared_memory.py
@@ -39,7 +39,11 @@ class SharedMemory:
     async def search(self, embedding: List[float], limit: int = 5) -> List[SharedMemoryModel]:
         self._validate_embedding(embedding)
         async with self.session_manager as session:
-            dialect = session.bind.dialect.name if session.bind is not None else ""
+            # Prefer engine dialect detection to avoid None bind on async sessions
+            try:
+                dialect = self.session_manager.engine.dialect.name
+            except Exception:
+                dialect = ""
             use_vector = Vector is not None and dialect == "postgresql"
             if use_vector:
                 stmt = (

--- a/core/state/state_manager.py
+++ b/core/state/state_manager.py
@@ -20,6 +20,10 @@ from core.proc.exec_log import ExecLog as ExecLogData
 from core.telemetry import telemetry
 from core.ui.base import UIBase
 from core.ui.base import UserInput as UserInputData
+try:  # optional memory
+    from core.memory import SharedMemory
+except Exception:  # pragma: no cover
+    SharedMemory = None
 
 if TYPE_CHECKING:
     from core.agents.base import BaseAgent
@@ -53,6 +57,10 @@ class StateManager:
         self.git_available = False
         self.git_used = False
         self.options = {}
+        if SharedMemory is not None:
+            self.shared_memory = SharedMemory(session_manager)
+        else:  # pragma: no cover - memory not available
+            self.shared_memory = None
 
     @asynccontextmanager
     async def db_blocker(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,6 @@ tqdm==4.67.1
 typing-extensions==4.12.2
 urllib3==2.2.3
 wcwidth==0.2.13
+asyncpg==0.29.0
+psycopg2-binary==2.9.9
+pgvector==0.2.5


### PR DESCRIPTION
## Summary
- add shared memory model using PostgreSQL pgvector
- expose shared memory manager to all agents via `StateManager`
- include migration and dependencies for pgvector support

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c042f9e5588333a7141a5445c3f47a

## Summary by Sourcery

Introduce an optional vector-based shared memory layer using PostgreSQL pgvector, integrated into the state manager and exposed to agents.

New Features:
- Add SharedMemory class for storing embeddings and performing vector searches.
- Expose shared memory manager via StateManager.shared_memory and agent.memory.
- Include Alembic migration and SQLAlchemy model for the shared_memory table with pgvector support.

Build:
- Add asyncpg, psycopg2-binary, and pgvector to project dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces shared memory accessible across agents for storing and retrieving content.
  - Enables semantic search over stored content when vector support is available; gracefully degrades when not.
  - Automatically provisions the required database table via migration.

- Chores
  - Adds database and vector-related dependencies to support shared memory and semantic search.

- Migrations
  - Applies a new migration to create the shared memory table with vector embeddings where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->