### PR TITLE
fix: detect pgvector through column attributes

### DIFF
--- a/core/memory/shared_memory.py
+++ b/core/memory/shared_memory.py
@@ -4,7 +4,7 @@ from typing import List
 
 from sqlalchemy import select
 
-from core.db.models.shared_memory import SharedMemory as SharedMemoryModel, Vector
+from core.db.models.shared_memory import SharedMemory as SharedMemoryModel
 from core.db.session import SessionManager
 
 
@@ -44,11 +44,13 @@ class SharedMemory:
                 dialect = self.session_manager.engine.dialect.name
             except Exception:
                 dialect = ""
-            use_vector = Vector is not None and dialect == "postgresql"
+            # Detect pgvector by attribute presence on the column expression
+            embedding_col = SharedMemoryModel.embedding
+            use_vector = hasattr(embedding_col, "cosine_distance") and dialect == "postgresql"
             if use_vector:
                 stmt = (
                     select(SharedMemoryModel)
-                    .order_by(SharedMemoryModel.embedding.cosine_distance(embedding))
+                    .order_by(embedding_col.cosine_distance(embedding))
                     .limit(limit)
                 )
             else:


### PR DESCRIPTION
## Summary
- detect pgvector support via column `cosine_distance` attribute rather than static import
- order vector search using the mapped embedding column

## Testing
- `pytest` *(fails: sqlite OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_68c05b7cca84833398c71a9a2a76c3f8