### PR TITLE
fix: cross-dialect UUIDs and rebuild Ollama client

### DIFF
--- a/core/llm/ollama_client.py
+++ b/core/llm/ollama_client.py
@@ -1,5 +1,8 @@
-from typing import Optional
+"""Client for interacting with a local Ollama server."""
 
+from typing import Any, Optional
+
+import httpx
 from ollama import AsyncClient
 
 from core.config import LLMProvider
@@ -12,12 +15,7 @@ class OllamaClient(BaseLLMClient):
 
     provider = LLMProvider.OLLAMA
 
-# core/llm/ollama_client.py
-
-from core.config import LLMProvider
-import httpx
-
-    def _init_client(self):
+    def _init_client(self) -> None:
         timeout = httpx.Timeout(
             connect=self.config.connect_timeout,
             read=self.config.read_timeout,
@@ -26,15 +24,15 @@ import httpx
             host=self.config.base_url or "http://localhost:11434",
             timeout=timeout,
         )
+
     async def _make_request(
         self,
         convo: Convo,
         temperature: Optional[float] = None,
         json_mode: bool = False,
     ) -> tuple[str, int, int]:
-        # … any preceding code …
+        """Stream a chat completion from the local Ollama server."""
 
-        # Wire through format="json" when json_mode is requested
         kwargs: dict[str, Any] = {}
         if json_mode:
             kwargs["format"] = "json"
@@ -43,29 +41,17 @@ import httpx
             model=self.config.model,
             messages=convo.messages,
             stream=True,
-            options={
-                "temperature": (
-                    self.config.temperature
-                    if temperature is None
-                    else temperature
-                )
-            },
+            options={"temperature": (self.config.temperature if temperature is None else temperature)},
             **kwargs,
         )
 
-        # … rest of the method …
-        stream = await self.client.chat(
-            model=self.config.model,
-            messages=convo.messages,
-            stream=True,
-            options={"temperature": self.config.temperature if temperature is None else temperature},
-        )
-        response_chunks = []
+        response_chunks: list[str] = []
         async for chunk in stream:
             message = chunk.get("message", {})
             content = message.get("content")
             if not content:
                 continue
+
             response_chunks.append(content)
             if self.stream_handler:
                 await self.stream_handler(content)
@@ -74,9 +60,12 @@ import httpx
             await self.stream_handler(None)
 
         full_response = "".join(response_chunks)
-        # Ollama currently does not return token usage, so approximate using whitespace tokenization.
+
+        # Ollama currently does not return token usage, so approximate using
+        # whitespace tokenization.
         prompt_tokens = sum(len(msg.get("content", "").split()) for msg in convo.messages)
         completion_tokens = len(full_response.split())
+
         return full_response, prompt_tokens, completion_tokens
 
 

--- a/tests/db/test_shared_memory.py
+++ b/tests/db/test_shared_memory.py
@@ -1,0 +1,28 @@
+import pytest
+from sqlalchemy import select
+
+from core.config import DBConfig
+from core.db.models import SharedMemory
+from core.db.session import SessionManager
+from core.db.setup import run_migrations
+
+
+@pytest.mark.asyncio
+async def test_bulk_insert_generates_unique_ids(tmp_path):
+    db_cfg = DBConfig(url=f"sqlite+aiosqlite:///{tmp_path}/test.db")
+    run_migrations(db_cfg)
+    manager = SessionManager(db_cfg)
+    async with manager as db:
+        records = [
+            {"agent_type": "a", "content": "foo", "embedding": [0.0]},
+            {"agent_type": "b", "content": "bar", "embedding": [0.1]},
+        ]
+        await db.execute(SharedMemory.__table__.insert(), records)
+        await db.commit()
+
+        q = await db.execute(select(SharedMemory.id))
+        ids = [row[0] for row in q]
+
+        assert len(ids) == 2
+        assert len(set(ids)) == 2
+        assert all(isinstance(i, str) and len(i) == 36 for i in ids)


### PR DESCRIPTION
## Summary
- avoid Postgres-specific UUID defaults in `SharedMemory` by generating IDs in Python
- rebuild `OllamaClient` with timeout configuration, JSON mode support, and token usage estimation

## Testing
- `pre-commit run --files core/llm/ollama_client.py core/db/models/shared_memory.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c05cb4918c83339cdbe34e6a125b88

## Summary by Sourcery

Rebuild OllamaClient to support JSON-mode streaming, configurable timeouts, and token usage estimation, and update SharedMemory to use Python-side UUID generation for cross-dialect compatibility.

New Features:
- Add JSON mode support for streaming responses in OllamaClient
- Allow configurable timeout in OllamaClient requests
- Approximate token usage in OllamaClient via whitespace tokenization

Bug Fixes:
- Generate UUIDs in Python for SharedMemory to avoid Postgres-specific defaults breaking other dialects

Enhancements:
- Refactor OllamaClient _make_request into a unified async streaming implementation with docstrings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Streaming responses with chunk-by-chunk delivery and safe finalization.
  - More accurate token usage reporting with optional tokenizer support and sensible fallback.
  - Improved client initialization with configurable timeouts and base URL.

- Bug Fixes
  - More reliable ID generation across databases (no dependency on database-specific UUID functions).
  - Robust handling when tokenizer package is not installed.

- Tests
  - Added tests validating unique, correctly formatted IDs during bulk inserts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->