### PR TITLE
Fix bug hunting cycle handling and API path parsing

### DIFF
--- a/core/agents/bug_hunter.py
+++ b/core/agents/bug_hunter.py
@@ -56,7 +56,7 @@ class BugHunter(ChatWithBreakdownMixin, BaseAgent):
             cycles = current_iteration.get("bug_hunting_cycles") or []
             if cycles and (cycles[-1].get("backend_logs") or cycles[-1].get("frontend_logs")):
                 return await self.check_logs()
-            await self.ui.send_bug_hunter_status("close_status", 0)
+            await self.ui.send_bug_hunter_status("close_status", len(cycles))
             return await self.ask_user_to_test(True, False)
         elif current_iteration["status"] == IterationStatus.AWAITING_USER_TEST:
             await self.ui.send_bug_hunter_status("close_status", 0)
@@ -128,6 +128,13 @@ class BugHunter(ChatWithBreakdownMixin, BaseAgent):
 
     async def ask_user_to_test(self, awaiting_bug_reproduction: bool = False, awaiting_user_test: bool = False):
         await self.ui.stop_app()
+        cycles = self.next_state.current_iteration.get("bug_hunting_cycles")
+        if cycles is None:
+            cycles = list(self.current_state.current_iteration.get("bug_hunting_cycles") or [])
+            self.next_state.current_iteration["bug_hunting_cycles"] = cycles
+        if not cycles:
+            cycles.append({})
+            self.next_state.flag_iterations_as_modified()
         test_instructions = self.current_state.current_iteration["bug_reproduction_description"]
         await self.ui.send_message(
             "Start the app and test it by following these instructions:\n\n", source=pythagora_source

--- a/core/state/state_manager.py
+++ b/core/state/state_manager.py
@@ -1,8 +1,8 @@
 import asyncio
 import os.path
 import traceback
-from pathlib import Path
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID, uuid4
 
@@ -682,7 +682,8 @@ class StateManager:
         """
         apis = []
         for file in self.next_state.files:
-            if "client/src/api" not in file.path:
+            parts = Path(file.path).parts
+            if not ("client" in parts and "src" in parts and "api" in parts):
                 continue
 
             session = inspect(file).async_session
@@ -699,7 +700,7 @@ class StateManager:
                 description = line.split(":", 1)[1].strip()
                 data = {"endpoint": "", "request": "", "response": ""}
                 # Scan subsequent lines for metadata in any order
-                for next_line in lines[i+1:]:
+                for next_line in lines[i + 1 :]:
                     next_line = next_line.strip()
                     if next_line.startswith("// Description:"):
                         break  # Stop if a new description starts
@@ -707,14 +708,9 @@ class StateManager:
                         prefix = f"// {key}:"
                         if next_line.startswith(prefix):
                             data[key.lower()] = next_line.split(":", 1)[1].strip()
-                for next_line in lines[i + 1 :]:
-                    next_line = next_line.strip()
-                    if next_line.startswith("// Description:"):
-                        break
-                    for key in ["Endpoint", "Request", "Response"]:
-                        prefix = f"// {key}:"
-                        if next_line.startswith(prefix):
-                            data[key.lower()] = next_line.split(":", 1)[1].strip()
+
+                if not data["endpoint"]:
+                    continue
 
                 backend = (
                     next(
@@ -735,7 +731,7 @@ class StateManager:
                         "request": data["request"],
                         "response": data["response"],
                         "locations": {
-                            "frontend": {"path": file.path, "line": i - 1},
+                            "frontend": {"path": file.path, "line": i + 1},
                             "backend": backend,
                         },
                         "status": "implemented" if backend is not None else "mocked",
@@ -743,17 +739,19 @@ class StateManager:
                 )
         return apis
 
-    async def update_apis(self, files_with_implemented_apis: list[dict] = []):
+    async def update_apis(self, files_with_implemented_apis: Optional[list[dict]] = None):
         """
         Update the list of APIs.
 
         """
+        if files_with_implemented_apis is None:
+            files_with_implemented_apis = []
         apis = await self.get_apis()
         for file in files_with_implemented_apis:
             for endpoint_info in file["endpoints"]:
                 endpoint = endpoint_info["endpoint"]
                 line = endpoint_info["line"]
-                api = next((api for api in apis if (endpoint in api["endpoint"])), None)
+                api = next((api for api in apis if endpoint == api["endpoint"]), None)
                 if api is not None:
                     api["status"] = "implemented"
                     api["locations"]["backend"] = {"path": file["path"], "line": line}


### PR DESCRIPTION
## Summary
- show correct bug hunting cycle count and safely initialize cycles
- parse frontend API metadata robustly for cross-platform paths
- avoid mutable defaults and fuzzy endpoint matches when updating APIs

## Testing
- `pre-commit run --files core/agents/bug_hunter.py core/state/state_manager.py` *(fails: Target database is not up to date)*
- `SKIP=alembic,pytest pre-commit run --files core/agents/bug_hunter.py core/state/state_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0c75d35c08333af9123d75eb5a019