### PR TITLE
Fix tech lead indentation and remove unused global

### DIFF
--- a/core/agents/tech_lead.py
+++ b/core/agents/tech_lead.py
@@ -51,35 +51,6 @@ class TechLead(RelevantFilesMixin, BaseAgent):
 
     async def run(self) -> AgentResponse:
         state = self.current_state
-
-# --- core/agents/tech_lead.py
-
-# 1) In plan_epic(...), use the passed-in epic instead of current_state.current_epic
-     def plan_epic(self, epic, ...):
-         # ...
-        task_type=epic.get("source", "app"),
-         # ...
-
-# 2) In create_initial_project_epic(), record the new epic as current_epic
-     def create_initial_project_epic(self):
-         log.debug("Creating initial project Epic")
--        self.next_state.epics = self.current_state.epics + [
-        new_epic = {
-             "id": uuid4().hex,
-             "name": "Initial Project",
-             "source": "app",
-             "description": self.current_state.specification.description,
-             "test_instructions": None,
-             "summary": None,
-             "completed": False,
-             "complexity": self.current_state.specification.complexity,
-             "sub_epics": [],
--            }
-        }
-        self.next_state.epics = self.current_state.epics + [new_epic]
-        self.next_state.current_epic = new_epic
-         self.next_state.relevant_files = None
-         self.next_state.modified_files = {}
         # Building frontend is the first epic - if the only epic is completed, start the initial project
         if len(state.epics) == 1 and state.epics[0].get("completed"):
             self.create_initial_project_epic()
@@ -103,19 +74,18 @@ class TechLead(RelevantFilesMixin, BaseAgent):
 
     def create_initial_project_epic(self):
         log.debug("Creating initial project Epic")
-        self.next_state.epics = self.current_state.epics + [
-            {
-                "id": uuid4().hex,
-                "name": "Initial Project",
-                "source": "app",
-                "description": self.current_state.specification.description,
-                "test_instructions": None,
-                "summary": None,
-                "completed": False,
-                "complexity": self.current_state.specification.complexity,
-                "sub_epics": [],
-            }
-        ]
+        new_epic = {
+            "id": uuid4().hex,
+            "name": "Initial Project",
+            "source": "app",
+            "description": self.current_state.specification.description,
+            "test_instructions": None,
+            "summary": None,
+            "completed": False,
+            "complexity": self.current_state.specification.complexity,
+            "sub_epics": [],
+        }
+        self.next_state.epics = self.current_state.epics + [new_epic]
         self.next_state.relevant_files = None
         self.next_state.modified_files = {}
 
@@ -206,7 +176,7 @@ class TechLead(RelevantFilesMixin, BaseAgent):
             .template(
                 "plan",
                 epic=epic,
-                task_type=self.current_state.current_epic.get("source", "app"),
+                task_type=epic.get("source", "app"),
                 # FIXME: we're injecting summaries to initial description
                 existing_summary=None,
                 get_only_api_files=True,

--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -257,8 +257,6 @@ async def async_main(
     :param args: Command-line arguments.
     :return: True if the application ran successfully, False otherwise.
     """
-    global telemetry_sent
-
     if args.list:
         await list_projects(db)
         return True


### PR DESCRIPTION
## Summary
- remove leftover diff markers and create initial epic cleanly
- use incoming epic for task planning
- drop unused telemetry global from CLI entry point

## Testing
- `pre-commit run --files core/agents/tech_lead.py core/cli/main.py` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f2da744c83338e0eb7c376982f83