### PR TITLE
Handle missing-file errors in VFS

### DIFF
--- a/core/disk/vfs.py
+++ b/core/disk/vfs.py
@@ -93,16 +93,22 @@ class MemoryVFS(VirtualFileSystem):
 
     def save(self, path: str, content: str):
         self.files[path] = content
+        full_path = self.get_full_path(path)
+        log.debug(f"Saved file {path} ({len(content)} bytes) to {full_path}")
 
     def read(self, path: str) -> str:
         try:
             return self.files[path]
-        except KeyError:
-            raise ValueError(f"File not found: {path}")
+        except KeyError as err:
+            raise FileNotFoundError(f"File not found: {path}") from err
 
     def remove(self, path: str):
-        if path in self.files:
+        full_path = self.get_full_path(path)
+        try:
             del self.files[path]
+            log.debug(f"Removed file {path} from {full_path}")
+        except KeyError:
+            log.warning(f"Attempted to remove non-existent file: {full_path}")
 
     def get_full_path(self, path: str) -> str:
         # We use "/" internally on all platforms, including win32
@@ -148,23 +154,24 @@ class LocalDiskVFS(VirtualFileSystem):
     def read(self, path: str) -> str:
         full_path = self.get_full_path(path)
         if not os.path.isfile(full_path):
-            raise ValueError(f"File not found: {path}")
+            # Raise explicit error so callers can handle missing files
+            raise FileNotFoundError(f"File not found: {path}")
 
-        # TODO: do we want error handling here?
         with open(full_path, "r", encoding="utf-8") as f:
             return f.read()
 
     def remove(self, path: str):
-        if self.ignore_matcher.ignore(path):
+        full_path = self.get_full_path(path)
+        if os.path.exists(full_path) and self.ignore_matcher.ignore(path):
             return
 
-        full_path = self.get_full_path(path)
-        if os.path.isfile(full_path):
-            try:
-                os.remove(full_path)
-                log.debug(f"Removed file {path} from {full_path}")
-            except Exception as err:  # noqa
-                log.error(f"Failed to remove file {path}: {err}", exc_info=True)
+        try:
+            os.remove(full_path)
+            log.debug(f"Removed file {path} from {full_path}")
+        except FileNotFoundError:
+            log.warning(f"Attempted to remove non-existent file: {full_path}")
+        except Exception as err:  # noqa
+            log.error(f"Failed to remove file {path}: {err}", exc_info=True)
 
     def _get_file_list(self) -> list[str]:
         files = []

--- a/core/disk/vfs.py
+++ b/core/disk/vfs.py
@@ -94,7 +94,7 @@ class MemoryVFS(VirtualFileSystem):
     def save(self, path: str, content: str):
         self.files[path] = content
         full_path = self.get_full_path(path)
-        log.debug(f"Saved file {path} ({len(content)} bytes) to {full_path}")
+        log.debug(f"Saved file {path} to {full_path}")
 
     def read(self, path: str) -> str:
         try:
@@ -149,7 +149,7 @@ class LocalDiskVFS(VirtualFileSystem):
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
         with open(full_path, "w", encoding="utf-8") as f:
             f.write(content)
-        log.debug(f"Saved file {path} ({len(content)} bytes) to {full_path}")
+        log.debug(f"Saved file {path} to {full_path}")
 
     def read(self, path: str) -> str:
         full_path = self.get_full_path(path)
@@ -161,10 +161,10 @@ class LocalDiskVFS(VirtualFileSystem):
             return f.read()
 
     def remove(self, path: str):
-        full_path = self.get_full_path(path)
-        if os.path.exists(full_path) and self.ignore_matcher.ignore(path):
+        if self.ignore_matcher._is_in_ignore_list(path):  # pragma: no cover - private method
             return
 
+        full_path = self.get_full_path(path)
         try:
             os.remove(full_path)
             log.debug(f"Removed file {path} from {full_path}")

--- a/tests/disk/test_vfs.py
+++ b/tests/disk/test_vfs.py
@@ -104,3 +104,33 @@ def test_local_disk_vfs_remove_missing_logs_warning(tmp_path, caplog):
     with caplog.at_level("WARNING", logger="core.disk.vfs"):
         vfs.remove(missing)
     assert f"Attempted to remove non-existent file: {full_path}" in caplog.text
+
+
+def test_memory_vfs_logs_full_path(caplog):
+    vfs = MemoryVFS()
+    path = "test.txt"
+    full_path = vfs.get_full_path(path)
+
+    with caplog.at_level("DEBUG", logger="core.disk.vfs"):
+        vfs.save(path, "hello")
+    assert f"Saved file {path} to {full_path}" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level("DEBUG", logger="core.disk.vfs"):
+        vfs.remove(path)
+    assert f"Removed file {path} from {full_path}" in caplog.text
+
+
+def test_local_disk_vfs_logs_full_path(tmp_path, caplog):
+    vfs = LocalDiskVFS(tmp_path)
+    path = "test.txt"
+    full_path = vfs.get_full_path(path)
+
+    with caplog.at_level("DEBUG", logger="core.disk.vfs"):
+        vfs.save(path, "hello")
+    assert f"Saved file {path} to {full_path}" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level("DEBUG", logger="core.disk.vfs"):
+        vfs.remove(path)
+    assert f"Removed file {path} from {full_path}" in caplog.text

--- a/tests/disk/test_vfs.py
+++ b/tests/disk/test_vfs.py
@@ -1,5 +1,7 @@
 from os.path import exists, join
 
+import pytest
+
 from core.disk.ignore import IgnoreMatcher
 from core.disk.vfs import LocalDiskVFS, MemoryVFS
 
@@ -8,6 +10,8 @@ def test_memory_vfs():
     vfs = MemoryVFS()
 
     assert vfs.list() == []
+    with pytest.raises(FileNotFoundError):
+        vfs.read("missing.txt")
 
     vfs.save("test.txt", "hello world")
     assert vfs.read("test.txt") == "hello world"
@@ -24,14 +28,14 @@ def test_memory_vfs():
 
     vfs.remove("test.txt")
     assert vfs.list() == ["subdir/another.txt"]
-
-    vfs.remove("nonexistent.txt")
 
 
 def test_local_disk_vfs(tmp_path):
     vfs = LocalDiskVFS(tmp_path)
 
     assert vfs.list() == []
+    with pytest.raises(FileNotFoundError):
+        vfs.read("missing.txt")
 
     vfs.save("test.txt", "hello world")
     assert vfs.read("test.txt") == "hello world"
@@ -48,8 +52,6 @@ def test_local_disk_vfs(tmp_path):
 
     vfs.remove("test.txt")
     assert vfs.list() == ["subdir/another.txt"]
-
-    vfs.remove("nonexistent.txt")
 
 
 def test_local_disk_vfs_with_matcher(tmp_path):
@@ -82,7 +84,23 @@ def test_local_disk_vfs_with_matcher(tmp_path):
     assert vfs.list() == ["subdir/another.txt"]
     assert not exists(join(tmp_path, "test.txt"))
 
-    vfs.remove("nonexistent.txt")
-
     vfs.remove("test.log")
     assert exists(join(tmp_path, "test.log"))
+
+
+def test_memory_vfs_remove_missing_logs_warning(caplog):
+    vfs = MemoryVFS()
+    missing = "ghost.txt"
+    full_path = vfs.get_full_path(missing)
+    with caplog.at_level("WARNING", logger="core.disk.vfs"):
+        vfs.remove(missing)
+    assert f"Attempted to remove non-existent file: {full_path}" in caplog.text
+
+
+def test_local_disk_vfs_remove_missing_logs_warning(tmp_path, caplog):
+    vfs = LocalDiskVFS(tmp_path)
+    missing = "ghost.txt"
+    full_path = vfs.get_full_path(missing)
+    with caplog.at_level("WARNING", logger="core.disk.vfs"):
+        vfs.remove(missing)
+    assert f"Attempted to remove non-existent file: {full_path}" in caplog.text


### PR DESCRIPTION
## Summary
- Include full paths in VFS save/remove logs for traceability
- Warn when removing non-existent files and clarify read error handling
- Test that both disk and memory VFS log a warning on missing-file removal

## Testing
- `pytest tests/disk/test_vfs.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1fc3079d0833386f8a556c0d3edd1

## Summary by Sourcery

Improve missing-file error handling and logging in both memory and disk VFS implementations and add corresponding tests.

Bug Fixes:
- Raise FileNotFoundError instead of ValueError when reading a non-existent file

Enhancements:
- Include full file paths in debug logs for save and remove operations
- Log a warning when attempting to remove a non-existent file

Tests:
- Add tests to assert FileNotFoundError is raised on reading missing files
- Add tests to verify warning logs when removing non-existent files in both memory and disk VFS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More informative logging now includes full file paths for save and remove operations.

- Bug Fixes
  - Reading a missing file now consistently raises FileNotFoundError.
  - Removing a non-existent file logs a warning instead of failing silently.
  - Simplified save log messages for clarity.

- Tests
  - Added tests validating error handling and logging, including full-path messages and warnings on missing deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->