### PR TITLE
Handle parallel agent exceptions

### DIFF
--- a/core/agents/orchestrator.py
+++ b/core/agents/orchestrator.py
@@ -90,13 +90,22 @@ class Orchestrator(BaseAgent, GitMixin):
                 log.debug(
                     f"Running agents {[a.__class__.__name__ for a in agent]} (step {self.current_state.step_index})"
                 )
-                responses = await asyncio.gather(*tasks)
-                for single_agent, single_response in zip(agent, responses):
+                raw_responses = await asyncio.gather(*tasks, return_exceptions=True)
+                responses = []
+                for single_agent, single_response in zip(agent, raw_responses):
+                    if isinstance(single_response, Exception):
+                        log.exception(
+                            "Agent %s failed during parallel execution",
+                            single_agent.agent_type,
+                            exc_info=single_response,
+                        )
+                        single_response = AgentResponse.error(single_agent, str(single_response))
+                    responses.append(single_response)
                     await self.message_broker.publish(
                         "agent.finish",
                         {
                             "agent": single_agent.agent_type,
-                            "status": single_response.type.value if single_response else "unknown",
+                            "response": single_response,
                         },
                     )
                 response = self.handle_parallel_responses(agent[0], responses)
@@ -130,9 +139,19 @@ class Orchestrator(BaseAgent, GitMixin):
 
             else:
                 await self.message_broker.publish("agent.start", agent.agent_type)
-                log.debug(f"Running agent {agent.__class__.__name__} (step {self.current_state.step_index})")
-                response = await agent.run()
-                await self.message_broker.publish("agent.finish", {"agent": agent.agent_type, "response": response})
+                log.debug(
+                    f"Running agent {agent.__class__.__name__} (step {self.current_state.step_index})"
+                )
+                try:
+                    response = await agent.run()
+                except Exception as exc:  # noqa: BLE001
+                    log.exception(
+                        "Agent %s failed during execution", agent.agent_type, exc_info=exc
+                    )
+                    response = AgentResponse.error(agent, str(exc))
+                await self.message_broker.publish(
+                    "agent.finish", {"agent": agent.agent_type, "response": response}
+                )
 
             if response.type == ResponseType.EXIT:
                 log.debug(f"Agent {agent.__class__.__name__} requested exit")


### PR DESCRIPTION
## Summary
- run parallel agents with asyncio.gather(return_exceptions=True) and publish each result
- convert raised exceptions into `AgentResponse.error` and log failures
- wrap sequential agent execution in try/except for consistent error handling

## Design Notes
- ensures orchestrator loop stays alive even if some agents fail
- preserves existing message broker semantics while exposing full responses

## Testing
- `pytest tests/agents/test_orchestrator.py -q`
- `pytest tests/ui/test_console.py::test_ask_question_buttons_only_non_verbose_silent -q`

## Risks
- message consumers expecting a `status` field on `agent.finish` events now receive `response`

## Follow-ups
- add dedicated tests for parallel agent failure scenarios


------
https://chatgpt.com/codex/tasks/task_e_68c2031af1b4833392f67e1121e10940