### PR TITLE
Add cancel option for unsupported frameworks and noisy Virtual UI

### DIFF
--- a/core/agents/architect.py
+++ b/core/agents/architect.py
@@ -21,6 +21,7 @@ from core.templates.registry import (
 ARCHITECTURE_STEP_NAME = "Project architecture"
 WARN_SYSTEM_DEPS = ["docker", "kubernetes", "microservices"]
 WARN_FRAMEWORKS = ["next.js", "vue", "vue.js", "svelte", "angular"]
+WARN_FRAMEWORKS_URL = "https://github.com/Pythagora-io/gpt-pilot/wiki/Using-GPT-Pilot-with-frontend-frameworks"
 
 log = get_logger(__name__)
 
@@ -221,7 +222,8 @@ class Architect(BaseAgent):
         # Offer cancel path to revise specification when unsupported frameworks are present
         if warn_frameworks:
             answer = await self.ask_question(
-                f"Pythagora doesn't support {', '.join(warn_frameworks)}. Continue anyway?",
+                f"Pythagora doesn't support {', '.join(warn_frameworks)}. Continue anyway? "
+                f"Visit {WARN_FRAMEWORKS_URL} for more information.",
                 buttons={"continue": "Continue", "cancel": "Cancel"},
                 buttons_only=True,
                 default="continue",
@@ -229,7 +231,7 @@ class Architect(BaseAgent):
             if getattr(answer, "button", None) == "cancel":
                 return AgentResponse.update_specification(
                     self,
-                    description="User cancelled; please reword specification.",
+                    description=f"User cancelled; unsupported frameworks: {', '.join(warn_frameworks)}. Please reword specification.",
                 )
 
         return None

--- a/core/ui/virtual.py
+++ b/core/ui/virtual.py
@@ -16,7 +16,6 @@ class VirtualUI(UIBase):
     def __init__(self, inputs: list[dict[str, str]]):
         self.virtual_inputs = [UserInput(**input) for input in inputs]
         self._app_link = None
-        self._streaming_logs = False
         self._important_stream_open = False
         self._breakdown_stream_open = False
 


### PR DESCRIPTION
## Summary
- allow the Architect to cancel and revise when frameworks are unsupported
- add observable no-op outputs and tracking flags to VirtualUI

## Design Notes
- Message broker already guards publish operations with a timeout, so no change was required

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c237db231c8333aa27b8ef272dc7fc

## Summary by Sourcery

Add cancellation path for unsupported frameworks in the Architect agent and enhance VirtualUI with no-op outputs and internal tracking flags.

New Features:
- Allow the Architect agent to cancel and revise the specification when unsupported frameworks are detected.

Enhancements:
- Remove unused frameworks URL constant and update the compatibility prompt in Architect.
- Add internal streaming logs flag and other state flags to VirtualUI.
- Simplify the send_key_expired output logic in VirtualUI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a cancel option when incompatible frameworks are detected, allowing users to exit gracefully.

- Bug Fixes
  - “Key expired” notice now always displays, even when no additional message is provided.

- Refactor
  - Simplified unsupported-framework guidance by removing the external link from prompts.
  - Streamlined follow-up text after a user cancels to a generic instruction to reword the specification.

- Chores
  - Minor internal cleanup and comments to clarify the new cancellation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->