### PR TITLE
Use Testcontainers to spin up PostgreSQL for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ pytest-cov = "^5.0.0"
 pytest-asyncio = "^0.23.6"
 pytest-timeout = "^2.3.1"
 pre-commit = "^3.7.0"
+testcontainers = "^4.13.0"
 
 [tool.pytest.ini_options]
 addopts = "-ra -q --cov=core --no-cov-on-fail --timeout 10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ asyncpg==0.29.0
 psycopg[binary]==3.2.10
 fastapi==0.116.1
 uvicorn==0.35.0
+testcontainers==4.13.0

--- a/tests/agents/test_orchestrator.py
+++ b/tests/agents/test_orchestrator.py
@@ -10,6 +10,7 @@ from core.agents.orchestrator import Orchestrator
 async def test_offline_changes_check_restores_if_workspace_empty():
     sm = AsyncMock()
     sm.workspace_is_empty = Mock(return_value=True)
+    sm.get_modified_files_with_content = AsyncMock(return_value=[])
     ui = AsyncMock()
     orca = Orchestrator(state_manager=sm, ui=ui)
     await orca.offline_changes_check()
@@ -22,6 +23,7 @@ async def test_offline_changes_check_imports_changes_from_disk():
     sm = AsyncMock()
     sm.workspace_is_empty = Mock(return_value=True)
     sm.import_files = AsyncMock(return_value=([], []))
+    sm.get_modified_files_with_content = AsyncMock(return_value=["foo.txt"])
     ui = AsyncMock()
     ui.ask_question.return_value.button = "yes"
     orca = Orchestrator(state_manager=sm, ui=ui)
@@ -35,6 +37,7 @@ async def test_offline_changes_check_imports_changes_from_disk():
 async def test_offline_changes_check_restores_changes_from_db():
     sm = AsyncMock()
     sm.workspace_is_empty = Mock(return_value=True)
+    sm.get_modified_files_with_content = AsyncMock(return_value=[])
     ui = AsyncMock()
     ui.ask_question.return_value.button = "no"
     orca = Orchestrator(state_manager=sm, ui=ui)
@@ -102,6 +105,7 @@ async def test_import_if_deleted_files(agentcontext):
 
     assert len(sm.current_state.files) == 0
 
+
 @pytest.mark.asyncio
 async def test_offline_changes_check_defaults_to_restore_on_unexpected_ui_response():
     # Framework: pytest + pytest-asyncio
@@ -117,6 +121,7 @@ async def test_offline_changes_check_defaults_to_restore_on_unexpected_ui_respon
     ui.ask_question.assert_called_once()
     sm.import_files.assert_not_called()
     sm.restore_files.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_import_files_no_changes_keeps_state(agentcontext):
@@ -135,6 +140,7 @@ async def test_import_files_no_changes_keeps_state(agentcontext):
 
     # Expect no new commit/state if import detects no changes
     assert sm.current_state == baseline
+
 
 @pytest.mark.asyncio
 async def test_import_files_reports_conflicts(agentcontext):
@@ -162,6 +168,7 @@ async def test_import_files_reports_conflicts(agentcontext):
     # If not present, at least ensure import_files was attempted.
     sm.import_files.assert_called_once()
 
+
 @pytest.mark.asyncio
 async def test_offline_changes_check_asks_and_imports_when_user_confirms(agentcontext):
     # Framework: pytest + pytest-asyncio
@@ -178,4 +185,3 @@ async def test_offline_changes_check_asks_and_imports_when_user_confirms(agentco
     ui.ask_question.assert_called_once()
     sm.import_files.assert_called_once()
     sm.restore_files.assert_not_called()
-

--- a/tests/db/test_db.py
+++ b/tests/db/test_db.py
@@ -8,12 +8,10 @@ from core.db.setup import run_migrations
 from .factories import create_project_state
 
 
-def test_migrations(tmp_path):
-    db_cfg = DBConfig(url="postgresql+asyncpg://postgres:postgres@localhost:5432/test")
-    try:
-        run_migrations(db_cfg)
-    except Exception:
-        pytest.skip("PostgreSQL not available")
+def test_migrations(postgres_container, tmp_path):
+    db_url = postgres_container.get_connection_url().replace("postgresql://", "postgresql+asyncpg://")
+    db_cfg = DBConfig(url=db_url)
+    run_migrations(db_cfg)
 
 
 @pytest.mark.asyncio

--- a/tests/db/test_shared_memory.py
+++ b/tests/db/test_shared_memory.py
@@ -8,12 +8,10 @@ from core.db.setup import run_migrations
 
 
 @pytest.mark.asyncio
-async def test_bulk_insert_generates_unique_ids(tmp_path):
-    db_cfg = DBConfig(url="postgresql+asyncpg://postgres:postgres@localhost:5432/test")
-    try:
-        run_migrations(db_cfg)
-    except Exception:
-        pytest.skip("PostgreSQL not available")
+async def test_bulk_insert_generates_unique_ids(tmp_path, postgres_container):
+    db_url = postgres_container.get_connection_url().replace("postgresql://", "postgresql+asyncpg://")
+    db_cfg = DBConfig(url=db_url)
+    run_migrations(db_cfg)
     manager = SessionManager(db_cfg)
     async with manager as db:
         records = [


### PR DESCRIPTION
**Summary**
- start a Postgres container during tests to avoid widespread skips
- add testcontainers dependency
- update DB tests to use the containerized database
- import offline disk changes when workspace is empty

**Design Notes**
- pgvector image with test credentials mirrors docker-compose setup
- fixture skips gracefully if Docker/PostgreSQL are unavailable
- when no DB state exists but files are present, offline changes are imported automatically

**Testing**
- `pre-commit run --files core/agents/orchestrator.py tests/agents/test_orchestrator.py`
- `pytest tests/agents/test_orchestrator.py::test_offline_changes_check_restores_if_workspace_empty tests/agents/test_orchestrator.py::test_offline_changes_check_imports_changes_from_disk tests/agents/test_orchestrator.py::test_offline_changes_check_restores_changes_from_db tests/agents/test_orchestrator.py::test_offline_changes_check_defaults_to_restore_on_unexpected_ui_response tests/agents/test_orchestrator.py::test_offline_changes_check_asks_and_imports_when_user_confirms -q`

**Risks**
- requires Docker engine for full test coverage

**Follow-ups**
- enable Docker in CI to run the previously skipped tests
- investigate failing orchestrator offline-change test

------
https://chatgpt.com/codex/tasks/task_e_68c25505817c8333aee948fc7e15a918

## Summary by Sourcery

Use Testcontainers to start a PostgreSQL container for tests, update database fixtures and tests to use the containerized DB, and enhance the orchestrator to import disk changes when the workspace is empty.

New Features:
- Start a PostgreSQL container during tests using Testcontainers
- Import files from disk automatically in the orchestrator when the workspace is empty and disk changes exist

Enhancements:
- Add testcontainers as a project dependency
- Gracefully skip tests if Docker or PostgreSQL is unavailable

Build:
- Add testcontainers dependency to pyproject.toml and requirements.txt

Tests:
- Introduce a session‐scoped postgres_container fixture and update DB tests to use the container
- Adjust offline_changes_check tests with mocked get_modified_files_with_content to cover new import logic