### PR TITLE
chore: bump MarkupSafe to 2.1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Jinja2==3.1.4
 jiter==0.8.0
 jsonref==1.1.0
 Mako==1.3.7
-MarkupSafe==2.0.1
+MarkupSafe==2.1.5
 openai==1.40.6
 prompt-toolkit==3.0.48
 psutil==5.9.8


### PR DESCRIPTION
## Summary
- upgrade MarkupSafe from 2.0.1 to 2.1.5 to address known CVEs

## Design Notes
- maintain pinned dependency style for reproducible builds

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`

## Risks
- Upstream packages may introduce unforeseen incompatibilities, but current tests cover major interactions

## Follow-ups
- none


------
https://chatgpt.com/codex/tasks/task_e_68c2584e2a4483338253d03bf97b3361

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/gpt-pilot/42)
<!-- GitContextEnd -->