### PR TITLE
chore: configure workflows with poetry and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install poetry
+        python -m pip install poetry==1.8.2
         poetry install --with=dev
-    - name: Lint with ruff
-      run: poetry run ruff check --output-format github
-    - name: Check code style with ruff
-      run: poetry run ruff format --check --diff
+    - name: Run pre-commit
+      env:
+        SKIP: pytest
+      run: |
+        poetry run pre-commit run --all-files --show-diff-on-failure --color=always
     - name: Test with pytest
       run: poetry run pytest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build . --file Dockerfile --tag gpt-pilot:${{ github.sha }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,21 +19,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+        python -m pip install poetry==1.8.2
+        poetry install --with=dev
+    - name: Run pre-commit
+      env:
+        SKIP: pytest
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        poetry run pre-commit run --all-files --show-diff-on-failure --color=always
     - name: Test with pytest
-      run: |
-        pytest
+      run: poetry run pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,20 +21,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+        python -m pip install poetry==1.8.2
+        poetry install --with=dev
+    - name: Run pre-commit
+      env:
+        SKIP: pytest
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        poetry run pre-commit run --all-files --show-diff-on-failure --color=always
     - name: Test with pytest
-      run: |
-        pytest
+      run: poetry run pytest

--- a/tests/messaging/test_chat.py
+++ b/tests/messaging/test_chat.py
@@ -51,6 +51,7 @@ async def test_chat_get_nowait_multiple_messages():
     assert await chat.get_nowait() == "two"
     assert await chat.get_nowait() is None
 
+
 # ---------------------------------------------------------------------------
 # Additional tests to broaden coverage
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- unify Python setup and dependency installation across workflows with poetry
- run pre-commit in CI to lint and check style
- tag Docker images with the commit SHA for traceability
- apply ruff-format fixes to process management and messaging tests
- pin Poetry version to 1.8.2 in Python workflows for reproducible builds
- ensure LocalProcess handles all exceptions and ProcessManager waits for termination to avoid stray processes

## Design Notes
- pre-commit hooks run with `SKIP=pytest` since tests execute in a dedicated step
- workflows install dev dependencies via poetry to match local tooling
- ruff-format adjustments are purely stylistic

## Testing
- `poetry run pre-commit run --files core/proc/process_manager.py --show-diff-on-failure --color=always`
- `poetry run pytest`

## Risks
- pre-commit config still warns about deprecated hook stages

## Follow-ups
- migrate pre-commit configuration to remove deprecated stage warnings

------
https://chatgpt.com/codex/tasks/task_e_68c25e3574cc833380966e7a7692e373

## Summary by Sourcery

Configure GitHub workflows to unify Python setup and tooling via Poetry and pre-commit, upgrade setup-python actions, tag Docker images by commit SHA, and strengthen process management termination and exception handling

Enhancements:
- Catch all exceptions in LocalProcess.wait and ensure ProcessManager waits for termination to prevent stray processes

CI:
- Upgrade actions/setup-python to v5 and bump Python version to 3.12 in workflows
- Pin Poetry to version 1.8.2 and install dev dependencies via poetry in CI
- Run pre-commit hooks instead of standalone linter steps, skipping pytest stage
- Tag Docker images with the commit SHA for improved traceability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved process shutdown reliability: ensures processes are fully terminated and cleaned up; forces kill on unexpected errors to avoid hangs.
* Chores
  * CI upgraded to Python 3.12, standardized on Poetry 1.8.2 for dependencies, and consolidated linting via pre-commit; tests now run through Poetry.
  * Docker images now tagged by commit SHA and pushed under a new repository name for clearer traceability.
* Tests
  * Minor whitespace cleanup in a chat test (no functional impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->