### PR TITLE
Allow overriding database URL via environment variable

### DIFF
--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from os import getenv
 from os.path import abspath, dirname, isdir, join
 from typing import Any, Literal, Optional, Union
 
@@ -516,7 +517,12 @@ def get_config() -> Config:
 
     :return: Current configuration object.
     """
-    return adapt_for_bedrock(loader.config)
+    config = adapt_for_bedrock(loader.config)
+
+    if db_url := getenv("DATABASE_URL"):
+        config.db.url = db_url
+
+    return config
 
 
 __all__ = ["loader", "get_config"]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -108,6 +108,14 @@ def test_default_config():
     assert config.log.level == "DEBUG"
 
 
+def test_database_url_env_override(monkeypatch):
+    loader.config = Config()
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@db/test_db")
+
+    config = get_config()
+    assert config.db.url == "postgresql+asyncpg://postgres:postgres@db/test_db"
+
+
 @pytest.mark.parametrize(
     ("encoding", "bom"),
     [


### PR DESCRIPTION
## Summary
- read DATABASE_URL from the environment in `get_config`
- test config respects DATABASE_URL override

## Design Notes
- enables docker-compose to connect to Postgres container by honoring env settings

## Testing
- `pre-commit run --files core/config/__init__.py tests/config/test_config.py`
- `pytest tests/config/test_config.py::test_database_url_env_override -q`

------
https://chatgpt.com/codex/tasks/task_e_68c60ef5ea4083338fcf8e37e2827f29

## Summary by Sourcery

Enable reading DATABASE_URL from the environment in get_config to override config.db.url and validate this behavior with a new test.

New Features:
- Allow overriding the database URL in configuration via the DATABASE_URL environment variable

Tests:
- Add a test to verify that DATABASE_URL env var overrides the default database URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for overriding the database connection URL via the DATABASE_URL environment variable, enabling flexible runtime configuration across environments without code changes.

* Tests
  * Introduced automated tests to verify the environment variable correctly overrides the database URL and that default behavior remains unchanged when the variable is not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->