### PR TITLE
Handle missing frontend build in API server

### DIFF
--- a/core/web/server.py
+++ b/core/web/server.py
@@ -3,7 +3,7 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from core.config import DBConfig, get_config
@@ -74,8 +74,10 @@ async def delete_project(project_id: UUID):
 
 
 @app.get("/")
-def index() -> FileResponse:
-    return FileResponse(FRONTEND_DIST / "index.html")
+def index():
+    if FRONTEND_DIST.exists():
+        return FileResponse(FRONTEND_DIST / "index.html")
+    return HTMLResponse("<h1>GPT Pilot API</h1>")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- serve a simple HTML placeholder when the frontend build directory is missing
- avoid 500 errors when `/` is requested without built assets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c61db07a508333a12df629db79d15e

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/gpt-pilot/53)
<!-- GitContextEnd -->