### PR TITLE
Handle missing frontend build in API server

### DIFF
--- a/core/web/server.py
+++ b/core/web/server.py
@@ -80,13 +80,12 @@ async def delete_project(project_id: UUID):
 def index():
     if FRONTEND_INDEX.is_file():
         return FileResponse(FRONTEND_INDEX)
-    placeholder = (
+    return HTMLResponse(
         "<h1>GPT Pilot API</h1>"
         "<p>Frontend build not found. Run <code>npm run build</code> inside the "
         "<code>frontend/</code> directory and rebuild the image.</p>"
         '<p>API docs available at <a href="/docs">/docs</a>.</p>'
     )
-    return HTMLResponse(placeholder)
 
 
 if __name__ == "__main__":

--- a/core/web/server.py
+++ b/core/web/server.py
@@ -3,7 +3,7 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from core.config import DBConfig, get_config
@@ -16,7 +16,8 @@ app = FastAPI(title="GPT Pilot Web")
 ROOT_DIR = Path(__file__).resolve().parent.parent.parent
 FRONTEND_DIR = ROOT_DIR / "frontend"
 FRONTEND_DIST = FRONTEND_DIR / "dist"
-if FRONTEND_DIST.exists():
+FRONTEND_INDEX = FRONTEND_DIST / "index.html"
+if FRONTEND_INDEX.exists():
     app.mount("/assets", StaticFiles(directory=FRONTEND_DIST / "assets"), name="assets")
 
 db_config: Optional[DBConfig] = None
@@ -74,8 +75,10 @@ async def delete_project(project_id: UUID):
 
 
 @app.get("/")
-def index() -> FileResponse:
-    return FileResponse(FRONTEND_DIST / "index.html")
+def index():
+    if FRONTEND_INDEX.exists():
+        return FileResponse(FRONTEND_INDEX)
+    return HTMLResponse("<h1>GPT Pilot API</h1><p>Frontend build not found.</p>")
 
 
 if __name__ == "__main__":

--- a/core/web/server.py
+++ b/core/web/server.py
@@ -17,8 +17,10 @@ ROOT_DIR = Path(__file__).resolve().parent.parent.parent
 FRONTEND_DIR = ROOT_DIR / "frontend"
 FRONTEND_DIST = FRONTEND_DIR / "dist"
 FRONTEND_INDEX = FRONTEND_DIST / "index.html"
-if FRONTEND_INDEX.exists():
-    app.mount("/assets", StaticFiles(directory=FRONTEND_DIST / "assets"), name="assets")
+if FRONTEND_INDEX.is_file():
+    assets_dir = FRONTEND_DIST / "assets"
+    if assets_dir.is_dir():
+        app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
 
 db_config: Optional[DBConfig] = None
 
@@ -76,9 +78,15 @@ async def delete_project(project_id: UUID):
 
 @app.get("/")
 def index():
-    if FRONTEND_INDEX.exists():
+    if FRONTEND_INDEX.is_file():
         return FileResponse(FRONTEND_INDEX)
-    return HTMLResponse("<h1>GPT Pilot API</h1><p>Frontend build not found.</p>")
+    placeholder = (
+        "<h1>GPT Pilot API</h1>"
+        "<p>Frontend build not found. Run <code>npm run build</code> inside the "
+        "<code>frontend/</code> directory and rebuild the image.</p>"
+        '<p>API docs available at <a href="/docs">/docs</a>.</p>'
+    )
+    return HTMLResponse(placeholder)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- only mount static assets when `frontend/dist/index.html` exists
- serve HTML placeholder if `frontend/dist/index.html` is missing

## Design Notes
- guard against cases where `dist` exists without `index.html`

## Testing
- `pytest -q`

## Risks
- placeholder page is minimal and may need further expansion in future

## Follow-ups
- none

------
https://chatgpt.com/codex/tasks/task_e_68c61db07a508333a12df629db79d15e

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/gpt-pilot/54)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a clear HTML message when the frontend build is missing so users know why the UI isn’t available.
  * Only serves the built frontend when a valid index file is present, improving startup resilience.

* **Bug Fixes**
  * Prevents startup errors when frontend assets are absent.
  * Ensures the root route reliably returns either the frontend or a helpful fallback instead of a blank or broken page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->